### PR TITLE
10% valider code in kommentaren betrifft faktisch jeden kommentar.

### DIFF
--- a/HDNETBlack/ruleset.xml
+++ b/HDNETBlack/ruleset.xml
@@ -25,7 +25,7 @@
     <rule ref="Squiz.Scope.StaticThisUsage"/>
     <rule ref="Squiz.PHP.CommentedOutCode">
     	<properties>
-    		<property name="maxPercentage" value="10"/>
+    		<property name="maxPercentage" value="80"/>
 		</properties>
     </rule>
 


### PR DESCRIPTION
normaler text entspricht fast immer mehr als 10% "validem" code.
