### PR TITLE
Heredoc-Regel entfernt

### DIFF
--- a/HDNETBlack/ruleset.xml
+++ b/HDNETBlack/ruleset.xml
@@ -38,7 +38,6 @@
     
 	<rule ref="Squiz.PHP.Eval"/>	
 	<rule ref="Squiz.PHP.GlobalKeyword"/>
-	<rule ref="Squiz.PHP.Heredoc"/>
     <rule ref="Squiz.PHP.NonExecutableCode"/>
     <rule ref="Squiz.Operators.ValidLogicalOperators"/>
 	<rule ref="Squiz.Objects.ObjectMemberComma"/>


### PR DESCRIPTION
Es gibt durchaus eine Menge sinnvoller Anwendungsfälle für heredoc: Mehrzeilige SQL-Statements, GraphQL-Queries, Elasticsearch-Queries, etc